### PR TITLE
Update README.md to fix error in Grammar example

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ class Variable(val name: String) : Item
 
 object ItemsParser : Grammar<List<Item>>() {
     val num by token("\\d+")
-    val word by token("[A-Za-z]")
+    val word by token("[A-Za-z]+")
     val comma by token(",\\s+")
 
     val numParser by num use { Number(text.toInt()) }


### PR DESCRIPTION
the example was missing a + in the regex for the word token, i'm assuming it was a typo