### PR TITLE
Fix InvalidMutabilityException in RegexToken

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -15,8 +15,7 @@ kotlin {
         }
         commonTest {
             dependencies {
-                implementation(kotlin("test-common"))
-                implementation(kotlin("test-annotations-common"))
+                implementation(kotlin("test"))
             }
         }
     }
@@ -24,10 +23,6 @@ kotlin {
     jvm {
         compilations["main"].apply {
             kotlinOptions.jvmTarget = "1.8"
-
-            defaultSourceSet.dependencies {
-                implementation(kotlin("stdlib"))
-            }
         }
 
         compilations["test"].defaultSourceSet.dependencies {
@@ -45,6 +40,10 @@ kotlin {
             implementation(kotlin("test-js"))
         }
     }
+
+    macosX64 { }
+    linuxX64 { }
+    mingwX64 { }
 }
 
 allOpen.annotation("org.openjdk.jmh.annotations.State")
@@ -52,6 +51,9 @@ allOpen.annotation("org.openjdk.jmh.annotations.State")
 benchmark {
     targets.register("jvm")
     targets.register("js")
+    targets.register("macosX64")
+    targets.register("linuxX64")
+    targets.register("mingwX64")
 
     configurations["main"].apply {
         warmups = 5

--- a/src/linuxX64Test/kotlin/ConcurrentExecution.kt
+++ b/src/linuxX64Test/kotlin/ConcurrentExecution.kt
@@ -1,0 +1,34 @@
+import com.github.h0tk3y.betterParse.combinators.and
+import com.github.h0tk3y.betterParse.combinators.use
+import com.github.h0tk3y.betterParse.grammar.Grammar
+import com.github.h0tk3y.betterParse.lexer.regexToken
+import com.github.h0tk3y.betterParse.parser.Parser
+import com.github.h0tk3y.betterParse.parser.parseToEnd
+import com.github.h0tk3y.betterParse.utils.components
+import kotlin.native.concurrent.TransferMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.native.concurrent.Worker
+
+class ConcurrentExecution {
+
+    object TestGrammar : Grammar<Nothing>() {
+        override val rootParser: Parser<Nothing> get() = throw NoSuchElementException()
+
+        val a by regexToken("a")
+        val b by regexToken("b")
+
+        val parser = a and b and a use { components.map { it.type } }
+    }
+
+    @Test
+    fun foo() {
+        val worker = Worker.start()
+        worker.execute(TransferMode.UNSAFE, { "aba" }) { string ->
+            val tokens = TestGrammar.tokenizer.tokenize(string)
+            TestGrammar.parser.parseToEnd(tokens)
+        }.consume { result ->
+            assertEquals(listOf(TestGrammar.a, TestGrammar.b, TestGrammar.a), result)
+        }
+    }
+}

--- a/src/nativeMain/kotlin/com/github/h0tk3y/betterParse/lexer/com/github/h0tk3y/betterParse/lexer/RegexToken.kt
+++ b/src/nativeMain/kotlin/com/github/h0tk3y/betterParse/lexer/com/github/h0tk3y/betterParse/lexer/RegexToken.kt
@@ -27,10 +27,7 @@ public actual class RegexToken : Token {
         this.regex = prependPatternWithInputStart(pattern, emptySet())
     }
 
-    private val relativeInput = object : CharSequence {
-        var fromIndex: Int = 0
-        var input: CharSequence = ""
-
+    private class RelativeInput(val fromIndex: Int, val input: CharSequence) : CharSequence {
         override val length: Int get() = input.length - fromIndex
         override fun get(index: Int): Char = input[index + fromIndex]
         override fun subSequence(startIndex: Int, endIndex: Int) =
@@ -40,8 +37,7 @@ public actual class RegexToken : Token {
     }
 
     override fun match(input: CharSequence, fromIndex: Int): Int {
-        relativeInput.input = input
-        relativeInput.fromIndex = fromIndex
+        val relativeInput = RelativeInput(fromIndex, input)
 
         return regex.find(relativeInput)?.range?.let {
             val length = it.last - it.first + 1


### PR DESCRIPTION
Mutating `relativeInput` makes better-parse throw `InvalidMutabilityException` on iosX64 (probably on other Kotlin/Native platforms as well). This PR turns `relativeInput` into a local immutable object.